### PR TITLE
Workaround some plugins exceptions

### DIFF
--- a/Touch-Gestures-0.6.x/GesturesDaemon.cs
+++ b/Touch-Gestures-0.6.x/GesturesDaemon.cs
@@ -64,10 +64,8 @@ namespace TouchGestures
 
                 var store = new PluginSettingStore(plugin);
 
-                var stateBinding = store.Construct<IStateBinding>();
-
                 // ALL that extra reflection bs just to get valid keys
-                var property = stateBinding.GetType().FindPropertyWithAttribute<PropertyValidatedAttribute>();
+                var property = store.GetTypeInfo()?.FindPropertyWithAttribute<PropertyValidatedAttribute>();
 
                 if (property == null)
                     continue;


### PR DESCRIPTION
Some plugin throw exception when not constructed while a specific output mode is active. Ideally, these plugins should just not throw an exception as they can cause other issues within the driver.

I'm talking to you void.