### PR TITLE
Add some checks to the installer to make sure we don't throw on setup with broken .NET behaviors

### DIFF
--- a/Touch-Gestures.Installer/TouchGesturesInstaller.cs
+++ b/Touch-Gestures.Installer/TouchGesturesInstaller.cs
@@ -7,6 +7,7 @@ using System.IO.Compression;
 using System.Threading;
 using System;
 using System.Diagnostics;
+using System.Security;
 
 namespace TouchGestures.Installer
 {
@@ -24,8 +25,8 @@ namespace TouchGestures.Installer
 
         private static readonly Assembly assembly = Assembly.GetExecutingAssembly();
 
-        private static readonly FileInfo location = new(assembly.Location);
-        private static readonly DirectoryInfo? pluginsDirectory = location.Directory?.Parent;
+        private static readonly FileInfo? location = assembly == null ? null : new(assembly.Location);
+        private static readonly DirectoryInfo? pluginsDirectory = location?.Directory?.Parent;
 
         private readonly DirectoryInfo? OTDEnhancedOutputModeDirectory = null;
 
@@ -33,23 +34,45 @@ namespace TouchGestures.Installer
 
         public TouchGesturesInstaller()
         {
+            Log.Write(PLUGIN_NAME, $"Installer Constructor Running...", LogLevel.Debug);
+            Log.Write(PLUGIN_NAME, $"pluginsDirectory: '{pluginsDirectory}' ({pluginsDirectory?.Exists})", LogLevel.Debug);
+
             if (pluginsDirectory == null || !pluginsDirectory.Exists)
             {
                 Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{pluginsDirectory}'.", LogLevel.Error);
                 return;
             }
 
+            Log.Write(PLUGIN_NAME, $"Past Plugins Directory Check, now checking for Dependencies...", LogLevel.Debug);
+
             // Look for OTD.EnhancedOutputMode.dll within the plugins directory
-            foreach (var pluginDirectory in pluginsDirectory.GetDirectories())
+            try
             {
-                foreach (var file in pluginDirectory.GetFiles())
+                foreach (var pluginDirectory in pluginsDirectory.GetDirectories())
                 {
-                    if (file.Name == "OTD.EnhancedOutputMode.dll")
+                    foreach (var file in pluginDirectory.GetFiles())
                     {
-                        OTDEnhancedOutputModeDirectory = pluginDirectory;
-                        return;
+                        Log.Write(PLUGIN_NAME, $"file: '{file?.Name}'", LogLevel.Debug);
+
+                        if (file?.Name == "OTD.EnhancedOutputMode.dll")
+                        {
+                            OTDEnhancedOutputModeDirectory = pluginDirectory;
+                            return;
+                        }
                     }
                 }
+            }
+            catch (DirectoryNotFoundException dnf)
+            {
+                Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{dnf.Message}'.", LogLevel.Error);
+            }
+            catch (UnauthorizedAccessException ua)
+            {
+                Log.Write(PLUGIN_NAME, $"Access to plugins directory was denied : '{ua.Message}'.", LogLevel.Error);
+            }
+            catch (SecurityException s)
+            {
+                Log.Write(PLUGIN_NAME, $"Some security exception occurred : '{s.Message}'.", LogLevel.Error);
             }
         }
 

--- a/Touch-Gestures.Installer/TouchGesturesInstaller.cs
+++ b/Touch-Gestures.Installer/TouchGesturesInstaller.cs
@@ -35,11 +35,20 @@ namespace TouchGestures.Installer
         public TouchGesturesInstaller()
         {
             Log.Write(PLUGIN_NAME, $"Installer Constructor Running...", LogLevel.Debug);
-            Log.Write(PLUGIN_NAME, $"pluginsDirectory: '{pluginsDirectory}' ({pluginsDirectory?.Exists})", LogLevel.Debug);
 
-            if (pluginsDirectory == null || !pluginsDirectory.Exists)
+            try
             {
-                Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{pluginsDirectory}'.", LogLevel.Error);
+                Log.Write(PLUGIN_NAME, $"pluginsDirectory: '{pluginsDirectory}' ({pluginsDirectory?.Exists})", LogLevel.Debug);
+
+                if (pluginsDirectory == null || !pluginsDirectory.Exists)
+                {
+                    Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{pluginsDirectory}'.", LogLevel.Error);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Write(PLUGIN_NAME, $"Broken .NET bahvior detected : Failed to even use the plugin directory variable: '{ex.Message}'.", LogLevel.Fatal);
                 return;
             }
 

--- a/Touch-Gestures.Installer/TouchGesturesInstaller.cs
+++ b/Touch-Gestures.Installer/TouchGesturesInstaller.cs
@@ -4,10 +4,7 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using System.IO;
 using System.IO.Compression;
-using System.Threading;
 using System;
-using System.Diagnostics;
-using System.Security;
 
 namespace TouchGestures.Installer
 {
@@ -25,63 +22,63 @@ namespace TouchGestures.Installer
 
         private static readonly Assembly assembly = Assembly.GetExecutingAssembly();
 
-        private static readonly FileInfo? location = assembly == null ? null : new(assembly.Location);
-        private static readonly DirectoryInfo? pluginsDirectory = location?.Directory?.Parent;
-
-        private readonly DirectoryInfo? OTDEnhancedOutputModeDirectory = null;
+        private readonly static FileInfo? location;
+        private readonly static DirectoryInfo? pluginsDirectory;
+        private readonly DirectoryInfo? OTDEnhancedOutputModeDirectory;
+        private static bool _isPathInitialized = false;
 
         private readonly string dependenciesResourcePath = $"Touch-Gestures.Installer.Touch-Gestures-{OTD_VERSION}.zip";
+
+        static TouchGesturesInstaller()
+        {
+            try
+            {
+                location = assembly == null ? null : new(assembly.Location);
+                pluginsDirectory = location?.Directory?.Parent;
+                _isPathInitialized = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Write(PLUGIN_NAME, $"Broken .NET bahvior detected : Failed to even use the plugin directory variable: '{ex.Message}'.", LogLevel.Fatal);
+            }
+        }
 
         public TouchGesturesInstaller()
         {
             Log.Write(PLUGIN_NAME, $"Installer Constructor Running...", LogLevel.Debug);
 
-            try
+            if (_isPathInitialized == false)
             {
-                Log.Write(PLUGIN_NAME, $"pluginsDirectory: '{pluginsDirectory}' ({pluginsDirectory?.Exists})", LogLevel.Debug);
-
-                if (pluginsDirectory == null || !pluginsDirectory.Exists)
-                {
-                    Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{pluginsDirectory}'.", LogLevel.Error);
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Write(PLUGIN_NAME, $"Broken .NET bahvior detected : Failed to even use the plugin directory variable: '{ex.Message}'.", LogLevel.Fatal);
+                Log.Write(PLUGIN_NAME, "Due to broken .NET bahavior, " +
+                                       $"Your only way forward is to manually install the 'Touch-Gestures-{OTD_VERSION}.zip' package " +
+                                       $"to the 'OTD.EnhancedOutputMode' plugin directory. {Environment.NewLine}" +
+                                       "This mean this installer is no longer necessary and can be uninstalled.", LogLevel.Fatal);
                 return;
             }
 
-            Log.Write(PLUGIN_NAME, $"Past Plugins Directory Check, now checking for Dependencies...", LogLevel.Debug);
+            Log.Write(PLUGIN_NAME, $"Plugin Directory : '{pluginsDirectory}' ({pluginsDirectory?.Exists})", LogLevel.Debug);
+
+            if (pluginsDirectory == null || !pluginsDirectory.Exists)
+            {
+                Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{pluginsDirectory}'.", LogLevel.Error);
+                return;
+            }
+
+            Log.Write(PLUGIN_NAME, $"Checking for OTD.EnhancedOutputMode directory...", LogLevel.Debug);
 
             // Look for OTD.EnhancedOutputMode.dll within the plugins directory
-            try
+            foreach (var pluginDirectory in pluginsDirectory.GetDirectories())
             {
-                foreach (var pluginDirectory in pluginsDirectory.GetDirectories())
+                foreach (var file in pluginDirectory.GetFiles())
                 {
-                    foreach (var file in pluginDirectory.GetFiles())
-                    {
-                        Log.Write(PLUGIN_NAME, $"file: '{file?.Name}'", LogLevel.Debug);
+                    Log.Write(PLUGIN_NAME, $"file: '{file?.Name}'", LogLevel.Debug);
 
-                        if (file?.Name == "OTD.EnhancedOutputMode.dll")
-                        {
-                            OTDEnhancedOutputModeDirectory = pluginDirectory;
-                            return;
-                        }
+                    if (file?.Name == "OTD.EnhancedOutputMode.dll")
+                    {
+                        OTDEnhancedOutputModeDirectory = pluginDirectory;
+                        return;
                     }
                 }
-            }
-            catch (DirectoryNotFoundException dnf)
-            {
-                Log.Write(PLUGIN_NAME, $"Failed to get plugins directory : '{dnf.Message}'.", LogLevel.Error);
-            }
-            catch (UnauthorizedAccessException ua)
-            {
-                Log.Write(PLUGIN_NAME, $"Access to plugins directory was denied : '{ua.Message}'.", LogLevel.Error);
-            }
-            catch (SecurityException s)
-            {
-                Log.Write(PLUGIN_NAME, $"Some security exception occurred : '{s.Message}'.", LogLevel.Error);
             }
         }
 

--- a/Touch-Gestures.Installer/TouchGesturesInstaller.cs
+++ b/Touch-Gestures.Installer/TouchGesturesInstaller.cs
@@ -71,8 +71,6 @@ namespace TouchGestures.Installer
             {
                 foreach (var file in pluginDirectory.GetFiles())
                 {
-                    Log.Write(PLUGIN_NAME, $"file: '{file?.Name}'", LogLevel.Debug);
-
                     if (file?.Name == "OTD.EnhancedOutputMode.dll")
                     {
                         OTDEnhancedOutputModeDirectory = pluginDirectory;


### PR DESCRIPTION
This should prevent an hard exception on MacOS for example or just setups with minimally broken installs.