### PR TITLE
Fix Installer for all platforms

### DIFF
--- a/Touch-Gestures.Installer/Touch-Gestures.Installer.csproj
+++ b/Touch-Gestures.Installer/Touch-Gestures.Installer.csproj
@@ -9,13 +9,13 @@
   <!-- NET 5 Only -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <!-- OpenTabletDriver.Plugin -->
-    <ProjectReference Include="../.modules/OTD.EnhancedOutputMode/.modules/OpenTabletDriver/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj" Private="False" />
+    <ProjectReference Include="../.modules/OTD.EnhancedOutputMode/.modules/OpenTabletDriver/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj" Private="False" />
   </ItemGroup>
 
   <!-- NET 6 Only -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <!-- OpenTabletDriver.Plugin -->
-    <ProjectReference Include="../.modules/OTD.EnhancedOutputMode-0.6.x/.modules/OpenTabletDriver/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj" Private="False" />
+    <ProjectReference Include="../.modules/OTD.EnhancedOutputMode-0.6.x/.modules/OpenTabletDriver/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj" Private="False" />
   </ItemGroup>
 
   <!-- embed ressource /build/plugin/Wheel-Addon.zip -->

--- a/Touch-Gestures.Installer/TouchGesturesInstaller.cs
+++ b/Touch-Gestures.Installer/TouchGesturesInstaller.cs
@@ -5,6 +5,8 @@ using OpenTabletDriver.Plugin.Attributes;
 using System.IO;
 using System.IO.Compression;
 using System;
+using OpenTabletDriver.Desktop.Reflection;
+using System.Runtime.Loader;
 
 namespace TouchGestures.Installer
 {
@@ -21,8 +23,9 @@ namespace TouchGestures.Installer
 #endif
 
         private static readonly Assembly assembly = Assembly.GetExecutingAssembly();
+        private static readonly DesktopPluginContext? context = AssemblyLoadContext.GetLoadContext(assembly) as DesktopPluginContext;
 
-        private readonly static FileInfo? location;
+        private readonly static DirectoryInfo? directory;
         private readonly static DirectoryInfo? pluginsDirectory;
         private readonly DirectoryInfo? OTDEnhancedOutputModeDirectory;
         private static bool _isPathInitialized = false;
@@ -33,13 +36,13 @@ namespace TouchGestures.Installer
         {
             try
             {
-                location = assembly == null ? null : new(assembly.Location);
-                pluginsDirectory = location?.Directory?.Parent;
+                directory = context?.Directory;
+                pluginsDirectory = directory?.Parent;
                 _isPathInitialized = true;
             }
             catch (Exception ex)
             {
-                Log.Write(PLUGIN_NAME, $"Broken .NET bahvior detected : Failed to even use the plugin directory variable: '{ex.Message}'.", LogLevel.Fatal);
+                Log.Write(PLUGIN_NAME, $"Broken .NET bahavior detected : Failed to even use the plugin directory variable: '{ex.Message}'.", LogLevel.Fatal);
             }
         }
 
@@ -88,6 +91,9 @@ namespace TouchGestures.Installer
 
         public static bool Install(Assembly assembly, string group, string resourcePath, DirectoryInfo? destinationDirectory, bool forceInstall = false)
         {
+            if (_isPathInitialized == false)
+                return false;
+
             if (pluginsDirectory == null || !pluginsDirectory.Exists)
             {
                 Log.Write(group, "Failed to get plugins directory.", LogLevel.Error);

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -131,11 +131,16 @@ build_installer () {
     echo ""
 
     # Build the installer
-    if ! dotnet publish Touch-Gestures.Installer -c Release -f $targetFramework -p:noWarn='"NETSDK1138;VSTHRD200"' -o build/installer/$version;
+    if ! dotnet publish Touch-Gestures.Installer -c Release -f $targetFramework -p:noWarn='"NETSDK1138;VSTHRD200"' -o temp/installer/$version;
     then
         echo "Failed to build Touch-Gestures.Installer for $version"
         exit 1
     fi
+
+    mkdir -p build/installer/$version
+
+    # Copy the installer to the output directory
+    cp temp/installer/$version/Touch-Gestures.Installer.* build/installer/$version
 
     (
         cd build/installer/$version
@@ -170,7 +175,7 @@ do
     echo "Building Touch-Gestures $version"
     echo ""
 
-    #Build the plugin, exit on failure
+    # Build the plugin, exit on failure
     if ! dotnet publish "Touch-Gestures$suffix" -c Release -p:noWarn='"NETSDK1138;VSTHRD200"' -o temp/plugin/$version ;
     then
         echo "Failed to build Touch-Gestures for $version"

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -22,6 +22,7 @@ main=("Touch-Gestures.dll"
       "OpenTabletDriver.External.Common.dll" 
       "Newtonsoft.Json.dll"
       "StreamJsonRpc.dll"
+      "Microsoft.Bcl.AsyncInterfaces.dll"
       "Touch-Gestures.pdb" 
       "Touch-Gestures.Lib.pdb"
       "OpenTabletDriver.External.Common.pdb")


### PR DESCRIPTION
We use `AssemblyLoadContext.GetLoadContext()` to get the context, which had a `Directory` property.
Also, we need to include another lib to make StreamJsonRpc work in 0.6.7.0 and later.